### PR TITLE
Fix include path after headers moved

### DIFF
--- a/quark.go
+++ b/quark.go
@@ -6,7 +6,7 @@
 package quark
 
 /*
-   #cgo CFLAGS: -I${SRCDIR}/src
+   #cgo CFLAGS: -I${SRCDIR}/include
    #cgo amd64 LDFLAGS: -Wl,--wrap=fmemopen ${SRCDIR}/libquark_big_amd64.a
    #cgo arm64 LDFLAGS: -Wl,--wrap=fmemopen ${SRCDIR}/libquark_big_arm64.a
 


### PR DESCRIPTION
src/ is not included in the distribution, include/ is, so go couldn't find quark.h.