### PR TITLE
Add quark_queue_get_stats(3) and quark_verbose binding

### DIFF
--- a/quark.go
+++ b/quark.go
@@ -126,6 +126,22 @@ type QueueAttr struct {
 	HoldTime       int
 }
 
+// Documented in https://elastic.github.io/quark/quark_queue_get_stats.3.html.
+type Stats struct {
+	Insertions      uint64
+	Removals        uint64
+	Aggregations    uint64
+	NonAggregations uint64
+	Lost            uint64
+	// backend          int (needs quark-0.2)
+}
+
+const (
+	QUARK_VL_SILENT = int(C.QUARK_VL_SILENT)
+	QUARK_VL_WARN   = int(C.QUARK_VL_WARN)
+	QUARK_VL_DEBUG  = int(C.QUARK_VL_DEBUG)
+)
+
 var ErrUndefined = errors.New("undefined")
 
 func wrapErrno(err error) error {
@@ -250,6 +266,26 @@ func (queue *Queue) Snapshot() []Process {
 	}
 
 	return processes
+}
+
+// Stats returns statistics of an active queue.
+func (queue *Queue) Stats() Stats {
+	var stats Stats
+	var cStats C.struct_quark_queue_stats
+
+	C.quark_queue_get_stats(queue.quarkQueue, &cStats)
+	stats.Insertions = uint64(cStats.insertions)
+	stats.Removals = uint64(cStats.removals)
+	stats.Aggregations = uint64(cStats.aggregations)
+	stats.NonAggregations = uint64(cStats.non_aggregations)
+	stats.Lost = uint64(cStats.lost)
+
+	return stats
+}
+
+// Sets quark verbosity globally, not per queue.
+func SetVerbose(level int) {
+	C.quark_verbose = C.int(level)
 }
 
 // processToGo converts the C process structure to a go process.


### PR DESCRIPTION
Allow go users to retrieve statistics, the documentation for each field can be found here: https://elastic.github.io/quark/quark_queue_get_stats.3.html

While here, start having more realistic tests, I plan to address this better in the upcoming weeks, so take the tests with a grain of salt.

SetVerbose() should really just be used for debugging and it will make quark spit logs to stderr.